### PR TITLE
updated how order configs are retrieved, no ExtensionInstall necessar…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/fleetops-api",
-    "version": "1.0.0-alpha",
+    "version": "1.0.1-alpha",
     "description": "FleetOps TMS and Last-Mile Operations System",
     "keywords": [
         "fleetops",

--- a/config/api.php
+++ b/config/api.php
@@ -60,75 +60,6 @@ $defaultFlow = [
     ]
 ];
 
-$storefrontFlow = [
-    'created' => [
-        'sequence' => 0,
-        'color' => 'green',
-        'events' => [
-            [
-                'status' => 'Order is being prepared',
-                'details' => 'Order has been received by {storefront.name} and is being prepared',
-                'code' => 'preparing',
-            ],
-            [
-                'status' => 'Order canceled',
-                'details' => 'Order could not be accepted',
-                'code' => 'canceled',
-            ],
-        ],
-    ],
-    'preparing' => [
-        'sequence' => 1,
-        'color' => 'orange',
-        'events' => [
-            [
-                'if' => [['meta.is_pickup', '=', true]],
-                'status' => 'Order is ready for pickup',
-                'details' => 'Order is ready to be picked up by customer.',
-                'code' => 'ready',
-            ],
-            [
-                'status' => 'Order dispatched',
-                'details' => 'Order has been dispatched to driver',
-                'code' => 'dispatched',
-            ],
-        ]
-    ],
-    'ready' => [
-        'sequence' => 2,
-        'color' => 'green',
-        'events' => [
-            [
-                'status' => 'Order picked up',
-                'details' => 'Order has been picked up by customer.',
-                'code' => 'completed',
-            ]
-        ]
-    ],
-    'dispatched' => [
-        'sequence' => 2,
-        'color' => 'blue',
-        'events' => [
-            [
-                'status' => 'Driver en-route',
-                'details' => 'Driver en-route to location',
-                'code' => 'driver_enroute',
-            ]
-        ]
-    ],
-    'driver_enroute' => [
-        'sequence' => 3,
-        'color' => 'green',
-        'events' => [
-            [
-                'status' => 'Order completed',
-                'details' => 'Driver has completed order',
-                'code' => 'completed',
-            ],
-        ]
-    ],
-];
-
 return [
     /*
     |--------------------------------------------------------------------------
@@ -301,15 +232,6 @@ return [
                 'meta_type' => 'order_config',
                 'meta' => [
                     'flow' => $defaultFlow,
-                ],
-            ],
-            [
-                'name' => 'Storefront',
-                'description' => 'Operational flow for storefront apps.',
-                'key' => 'storefront',
-                'meta_type' => 'order_config',
-                'meta' => [
-                    'flow' => $storefrontFlow,
                 ],
             ],
             [

--- a/src/Http/Controllers/Internal/v1/OrderConfigController.php
+++ b/src/Http/Controllers/Internal/v1/OrderConfigController.php
@@ -49,17 +49,19 @@ class OrderConfigController extends Controller
         // create array of configs
         $configs = collect([...$installedExtensions, ...$authored]);
 
+        // if no installed configs always place default config
+        if ($configs->isEmpty()) {
+            $configs = $configs->merge(Flow::getAllDefaultOrderConfigs());
+        }
+
+        // filter by key
         if ($key) {
             $configs = $configs->where('key', $key);
         }
 
+        // filter by namespace
         if ($namespace) {
             $configs = $configs->where('namespace', $namespace);
-        }
-
-        // if no installed configs always place default config
-        if ($configs->isEmpty() && $key === 'default') {
-            $configs->push(Flow::getDefaultOrderConfig());
         }
 
         if ($single) {


### PR DESCRIPTION
…y, extensions can now export their own order configs using the `order-config` key